### PR TITLE
Implement `linksmith anansi suggest`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,3 +5,6 @@
 ## v0.0.0 - 2024-xx-xx
 - Implement `linksmith inventory` and `linksmith output-formats`
   subcommands, based on `sphobjinv` and others. Thanks, @bskinn.
+- Implement `linksmith anansi suggest`, also available as `anansi`,
+  to easily suggest terms of a few curated community projects.
+  Thanks, @bskinn.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -9,13 +9,7 @@
 - Improve HTML output. (sticky breadcrumb/navbar, etc.)
 - More attractive JSON output
   https://github.com/tech-writing/linksmith/pull/4#discussion_r1546863551
-
-## Iteration +2
-sphobjinv call delegation ftw.
-```
-# Shorthand command ...
-anansi suggest matplotlib draw
-
-# ... for:
-sphobjinv suggest -u https://matplotlib.org/stable/ draw
-```
+- anansi: Display list of curated inventories.
+- anansi: Accept and delegate `threshold` and `score` parameters.
+- anansi: Expand list of curated projects to essentially any project, with
+  support of PyPI, RTD, or other project conventions.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,3 +46,19 @@ linksmith inventory \
   https://github.com/crate/crate-docs/raw/main/registry/sphinx-inventories.txt \
   --format=html+table
 ```
+
+
+## Anansi
+
+Suggest references from curated intersphinx inventories.
+
+:::{rubric} Synopsis
+:::
+
+```shell
+anansi suggest matplotlib draw
+```
+
+```shell
+anansi suggest sarge capture
+```

--- a/linksmith/cli.py
+++ b/linksmith/cli.py
@@ -7,6 +7,7 @@ from linksmith.settings import help_config
 
 from .model import OutputFormatRegistry
 from .sphinx.cli import cli as inventory_cli
+from .sphinx.community.anansi import cli as anansi_cli
 
 
 @click.group()
@@ -31,3 +32,4 @@ def output_formats(ctx: click.Context):  # noqa: ARG001
 
 cli.add_command(output_formats, name="output-formats")
 cli.add_command(inventory_cli, name="inventory")
+cli.add_command(anansi_cli, name="anansi")

--- a/linksmith/sphinx/community/anansi.py
+++ b/linksmith/sphinx/community/anansi.py
@@ -1,0 +1,102 @@
+"""
+Curated intersphinx mappings by Brian Skinn, with a CLI.
+
+Synopsis:
+
+    anansi suggest matplotlib draw
+
+Resources:
+- https://github.com/bskinn/intersphinx-gist
+- https://gist.github.com/bskinn/0e164963428d4b51017cebdb6cda5209
+"""
+
+import dataclasses
+import logging
+import sys
+
+import rich_click as click
+from pueblo.util.cli import boot_click
+
+from linksmith.settings import help_config
+from linksmith.sphinx.inventory import InventoryManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class Item:
+    name: str
+    url: str
+
+
+items = [
+    Item("python@3", "https://docs.python.org/3/"),
+    Item("python@3.9", "https://docs.python.org/3.9/"),
+    Item("attrs", "https://www.attrs.org/en/stable/"),
+    Item("django", "https://docs.djangoproject.com/en/dev/"),
+    Item("flask@2.2", "https://flask.palletsprojects.com/en/2.2.x/"),
+    Item("flask@1.1", "https://flask.palletsprojects.com/en/1.1.x/"),
+    Item("h5py", "https://docs.h5py.org/en/latest/"),
+    Item("matplotlib", "https://matplotlib.org/stable/"),
+    Item("numpy", "https://numpy.org/doc/stable/"),
+    Item("pandas", "https://pandas.pydata.org/docs/"),
+    Item("pyramid", "https://docs.pylonsproject.org/projects/pyramid/en/latest/"),
+    Item("scikit-learn", "https://scikit-learn.org/stable/"),
+    Item("sphinx", "https://www.sphinx-doc.org/en/master/"),
+    Item("sympy", "https://docs.sympy.org/latest/"),
+    Item("scipy", "https://docs.scipy.org/doc/scipy/"),
+    Item("scipy@1.8.1", "https://docs.scipy.org/doc/scipy-1.8.1/"),
+    Item("scipy@1.8.0", "https://docs.scipy.org/doc/scipy-1.8.0/"),
+    Item("scipy@1.7.1", "https://docs.scipy.org/doc/scipy-1.7.1/"),
+    Item("scipy@1.7.0", "https://docs.scipy.org/doc/scipy-1.7.0/"),
+    Item("scipy@1.6.3", "https://docs.scipy.org/doc/scipy-1.6.3/reference/"),
+    Item("sarge", "https://sarge.readthedocs.io/en/latest/"),
+]
+
+
+def suggest(project: str, term: str):
+    for item in items:
+        if item.name == project:
+            url = f"{item.url.rstrip('/')}/objects.inv"
+            inv = InventoryManager(url).soi_factory()
+            results = inv.suggest(term)
+            if results:
+                hits = len(results)
+                logger.info(f"{hits} hits for project/term: {project}/{term}")
+                return results
+            else:
+                logger.warning(f"No hits for project/term: {project}/{term}")
+                return []
+    else:
+        raise KeyError(f"Project not found: {project}")
+
+
+@click.group()
+@click.rich_config(help_config=help_config)
+@click.pass_context
+def cli(ctx: click.Context):
+    """
+    Run operations on curated community projects.
+    """
+    if not ctx.parent:
+        boot_click(ctx)
+
+
+@click.command()
+@click.rich_config(help_config=help_config)
+@click.argument("project")
+@click.argument("term")
+@click.pass_context
+def cli_suggest(ctx: click.Context, project: str, term: str):  # noqa: ARG001
+    """
+    Fuzzy-search intersphinx inventory for desired object(s).
+    """
+    try:
+        results = suggest(project, term)
+        print("\n".join(results))  # noqa: T201
+    except Exception as ex:
+        logger.error(str(ex).strip("'"))
+        sys.exit(1)
+
+
+cli.add_command(cli_suggest, name="suggest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ documentation = "https://linksmith.readthedocs.io/"
 homepage = "https://linksmith.readthedocs.io/"
 repository = "https://github.com/tech-writing/linksmith"
 [project.scripts]
+anansi = "linksmith.sphinx.community.anansi:cli"
 linksmith = "linksmith.cli:cli"
 
 [tool.black]

--- a/tests/test_anansi.py
+++ b/tests/test_anansi.py
@@ -1,0 +1,61 @@
+import linksmith
+from linksmith.cli import cli
+
+
+def test_anansi_pure(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+
+def test_anansi_suggest_project_missing(cli_runner):
+    result = cli_runner.invoke(
+        linksmith.sphinx.community.anansi.cli,
+        args="suggest",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+    assert "Missing argument 'PROJECT'" in result.output
+
+
+def test_anansi_suggest_term_missing(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest foo",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+    assert "Missing argument 'TERM'" in result.output
+
+
+def test_anansi_suggest_project_unknown(cli_runner, caplog):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest foo bar",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "Project not found: foo" in caplog.messages
+
+
+def test_anansi_suggest_hit(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest sarge capture",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert ":py:class:`sarge.Capture`" in result.output
+
+
+def test_anansi_suggest_miss(cli_runner, caplog):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest sarge foo",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No hits for project/term: sarge/foo" in caplog.messages


### PR DESCRIPTION
## About
To easily suggest terms of a few community projects curated by @bskinn, relating to improvements in [Community Operations](https://linksmith.readthedocs.io/en/latest/rfc.html#rfc-community-operations). `anansi suggest` is delegating to [sphobjinv](https://sphobjinv.readthedocs.io/).

## Synopsis
```
anansi suggest matplotlib draw
```

## Details
The program is available as both `linksmith anansi`, and also as `anansi` shorthand.

## Backlog
- [ ] Will need to forward `--score` and `--thresh`.
- [ ] Expand list of curated projects to essentially any project, with support of PyPI, RTD, or other project conventions.
