### PR TITLE
Improvements for `linksmith inventory` and `linksmith anansi`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.8", "3.12"]
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,3 +14,4 @@
 - Anansi: Provide `anansi list-projects` subcommand, to list curated
   projects managed in accompanying `curated.yaml` file.
 - Anansi: Accept `--threshold` option, forwarding to `sphobjinv`.
+- Anansi: Discover `objects.inv` also from RTD and PyPI.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,9 @@
 ## v0.0.0 - 2024-xx-xx
 - Implement `linksmith inventory` and `linksmith output-formats`
   subcommands, based on `sphobjinv` and others. Thanks, @bskinn.
-- Implement `linksmith anansi suggest`, also available as `anansi`,
+- Anansi: Implement `linksmith anansi suggest`, also available as `anansi`,
   to easily suggest terms of a few curated community projects.
   Thanks, @bskinn.
 - Accept `linksmith inventory` without `INFILES` argument, implementing
   auto-discovery of `objects.inv` in local current working directory.
+- Anansi: Manage project list in YAML file `curated.yaml`, not Python.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,3 +13,4 @@
 - Anansi: Manage project list in YAML file `curated.yaml`, not Python.
 - Anansi: Provide `anansi list-projects` subcommand, to list curated
   projects managed in accompanying `curated.yaml` file.
+- Anansi: Accept `--threshold` option, forwarding to `sphobjinv`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,3 +11,5 @@
 - Accept `linksmith inventory` without `INFILES` argument, implementing
   auto-discovery of `objects.inv` in local current working directory.
 - Anansi: Manage project list in YAML file `curated.yaml`, not Python.
+- Anansi: Provide `anansi list-projects` subcommand, to list curated
+  projects managed in accompanying `curated.yaml` file.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.md *.rst LICENSE
+recursive-include linksmith *.yaml
 recursive-include docs *.md *.rst
 prune release
 prune tests

--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ considering.
 [![Coverage status][badge-coverage]][project-codecov]
 
 
-## Why
+## What's Inside
 
-- Grown out of passion for [Sphinx], [Hyperlinks], and [DWIM],
-  and a sweet conversation at pueblo's sketch about [adding an inventory
-  decoder for Sphinx].
-- To learn [sphobjinv], and explore a few convenience heuristics around it.
-- To host code for community operations, alongside software tests and
-  packaging, in order to provide better maintainability and code re-use.
-- Along the lines of shuffling code around, provide a few tangible features
-  [collected the other day][rfc].
+- A few convenience wrappers around [`sphinx.ext.intersphinx`] and [sphobjinv].
+- Ideas to support [DWIM]-like tooling for [Sphinx] and [Hyperlinks],
+  coming from a sweet conversation at pueblo's sketch about [adding an
+  inventory decoder for Sphinx], summarized into a [feature wish list][rfc].
+- Code for community operations, alongside software tests and packaging,
+  in order to provide better maintainability and re-use.
+
+> [!WARNING]
+> Here be dragons. Please note the program is pre-alpha, and a work in
+> progress, so everything may change while we go.
 
 
 ## Setup
@@ -43,14 +45,8 @@ pip install 'linksmith @ git+https://github.com/tech-writing/linksmith.git'
 linksmith inventory https://linksmith.readthedocs.io/en/latest/objects.inv
 ```
 
-Read more at the [Linksmith Usage] documentation.
-
-The `linksmith inventory` subsystem is heavily based on
-`sphinx.ext.intersphinx` and `sphobjinv`.
-
-> [!WARNING]
-> Here be dragons. Please note the program is pre-alpha, and a work in
-> progress, so everything may change while we go.
+More details and other subsystems are outlined at the [Linksmith Usage]
+documentation.
 
 
 ## Development
@@ -108,6 +104,7 @@ lovely people around Sphinx and Read the Docs.
 [Linksmith Usage]: https://linksmith.readthedocs.io/en/latest/usage.html
 [rfc]: https://linksmith.readthedocs.io/en/latest/rfc.html
 [Sphinx]: https://www.sphinx-doc.org/
+[`sphinx.ext.intersphinx`]: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 [sphobjinv]: https://sphobjinv.readthedocs.io/
 [Sviatoslav Sydorenko]: https://github.com/webknjaz
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,15 +1,26 @@
 # Backlog
 
 ## Iteration +1
-- Docs: Based on sphobjinv.
-- Response caching to buffer subsequent invocations
+- Unlock accessing intersphinx mappings in `conf.py`
+- Access remote `conf.py` at GitHub or HTTP
 - Add output flavor, like `--details=compact,full`.
   **Full details**, well, should display **full URLs**, ready for
   navigational consumption (clicking).
-- Improve HTML output. (sticky breadcrumb/navbar, etc.)
-- More attractive JSON output
+- Look into intersphinx-untangled.
+- More attractive JSON output.
   https://github.com/tech-writing/linksmith/pull/4#discussion_r1546863551
-- anansi: Display list of curated inventories.
-- anansi: Accept and delegate `threshold` and `score` parameters.
-- anansi: Expand list of curated projects to essentially any project, with
+
+## Iteration +2
+- Improve HTML output. (sticky breadcrumb/navbar, etc.)
+- Response caching to buffer subsequent invocations
+- Anansi: Accept `with_index` and `with_score` options? 
+- Anansi: Support project versions by using an ingress notation like
+  `flask@2.2`
+- Anansi: Expand list of curated projects to essentially any project, with
   support of PyPI, RTD, or other project conventions.
+- Speed up `anansi suggest`, maybe introduce `anansi search` instead?
+
+## Done
+- Anansi: Display list of curated inventories.
+- Anansi: Accept and delegate `threshold` parameter.
+- Process multiple objects.inv: Strictness

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 # Linksmith
 
 A program for processing Hyperlinks, Sphinx references, and inventories.
+It is heavily based on [`sphinx.ext.intersphinx`] and [sphobjinv], and
+intends to provide [DWIM]-like tooling for [Sphinx] and [Hyperlinks].
 
 ::::::{grid} 1 3 3 3
 :margin: 4 4 0 0
@@ -72,3 +74,10 @@ Intrigued by MEP 0002? Enjoy reading [](inv:mep#meps/mep-0002).
 In order to start hacking on Linksmith, please refer to the documentation
 page about how to set up a [](#development-sandbox).
 :::
+
+
+[DWIM]: https://en.wikipedia.org/wiki/DWIM
+[Hyperlinks]: https://en.wikipedia.org/wiki/Hyperlink
+[Sphinx]: https://www.sphinx-doc.org/
+[`sphinx.ext.intersphinx`]: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+[sphobjinv]: https://sphobjinv.readthedocs.io/

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,10 +64,15 @@ Suggest references from curated intersphinx inventories.
 :::{rubric} Synopsis
 :::
 
+Run term suggestion on Sphinx documentation project, per its published `objects.inv` file.
+```shell
+anansi suggest sarge capture
+```
 ```shell
 anansi suggest matplotlib draw
 ```
 
+Display list of curated projects.
 ```shell
-anansi suggest sarge capture
+anansi list-projects
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,6 +56,7 @@ linksmith inventory
 ```
 
 
+(anansi)=
 ## Anansi
 
 Suggest references from curated intersphinx inventories.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,7 +59,8 @@ linksmith inventory
 (anansi)=
 ## Anansi
 
-Suggest references from curated intersphinx inventories.
+Suggest references from intersphinx inventories, derived from curated projects,
+RTD, or PyPI.
 
 :::{rubric} Synopsis
 :::
@@ -70,6 +71,12 @@ anansi suggest sarge capture
 ```
 ```shell
 anansi suggest matplotlib draw
+```
+```shell
+anansi suggest requests patch
+```
+```shell
+anansi suggest beradio json
 ```
 
 Display list of curated projects.

--- a/linksmith/model.py
+++ b/linksmith/model.py
@@ -61,10 +61,10 @@ class ResourceType(AutoStrEnum):
     def detect(cls, location):
         if isinstance(location, io.IOBase):
             return cls.BUFFER
+        if location.startswith("http://") or location.startswith("https://"):
+            return cls.URL
         path = Path(location)
         if path.exists():
             return cls.PATH
-        elif location.startswith("http://") or location.startswith("https://"):
-            return cls.URL
         else:
-            raise NotImplementedError(f"Resource type not implemented: {location}")
+            raise FileNotFoundError(f"Resource not found: {location}")

--- a/linksmith/sphinx/community/anansi.py
+++ b/linksmith/sphinx/community/anansi.py
@@ -57,6 +57,15 @@ class AnansiLibrary:
             data.append(Item(**raw))
         return data
 
+    def to_list(self):
+        """
+        Convert list of items into list of Python objects.
+        """
+        data = []
+        for item in self.items:
+            data.append(dataclasses.asdict(item))
+        return data
+
     def suggest(self, project: str, term: str):
         """
         Find occurrences for "term" in Sphinx inventory.
@@ -93,6 +102,18 @@ def cli(ctx: click.Context):
 
 @click.command()
 @click.rich_config(help_config=help_config)
+@click.pass_context
+def cli_list_projects(ctx: click.Context):  # noqa: ARG001
+    """
+    List curated projects managed in accompanying `curated.yaml` file.
+    """
+    library = AnansiLibrary()
+    results = library.to_list()
+    print(yaml.dump(results))  # noqa: T201
+
+
+@click.command()
+@click.rich_config(help_config=help_config)
 @click.argument("project")
 @click.argument("term")
 @click.pass_context
@@ -109,4 +130,5 @@ def cli_suggest(ctx: click.Context, project: str, term: str):  # noqa: ARG001
         sys.exit(1)
 
 
+cli.add_command(cli_list_projects, name="list-projects")
 cli.add_command(cli_suggest, name="suggest")

--- a/linksmith/sphinx/community/curated.yaml
+++ b/linksmith/sphinx/community/curated.yaml
@@ -1,0 +1,102 @@
+- name: python
+  version: 3
+  url: https://docs.python.org/3/
+  tags:
+    - bskinn
+- name: python
+  version: 3.9
+  url: https://docs.python.org/3.9/
+  tags:
+    - bskinn
+- name: attrs
+  url: https://www.attrs.org/en/stable/
+  tags:
+    - bskinn
+- name: django
+  url: https://docs.djangoproject.com/en/dev/
+  tags:
+    - bskinn
+- name: flask
+  version: 1.1
+  url: https://flask.palletsprojects.com/en/1.1.x/
+  tags:
+    - bskinn
+- name: flask
+  version: 2.2
+  url: https://flask.palletsprojects.com/en/2.2.x/
+  tags:
+    - bskinn
+- name: flask
+  version: 3.0
+  url: https://flask.palletsprojects.com/en/3.0.x/
+  tags:
+    - bskinn
+- name: h5py
+  url: https://docs.h5py.org/en/latest/
+  tags:
+    - bskinn
+- name: matplotlib
+  url: https://matplotlib.org/stable/
+  tags:
+    - bskinn
+- name: numpy
+  url: https://numpy.org/doc/stable/
+  tags:
+    - bskinn
+- name: pandas
+  url: https://pandas.pydata.org/docs/
+  tags:
+    - bskinn
+- name: pyramid
+  url: https://docs.pylonsproject.org/projects/pyramid/en/latest/
+  tags:
+    - bskinn
+- name: scikit-learn
+  url: https://scikit-learn.org/stable/
+  tags:
+    - bskinn
+- name: sphinx
+  url: https://www.sphinx-doc.org/en/master/
+  tags:
+    - bskinn
+- name: sympy
+  url: https://docs.sympy.org/latest/
+  tags:
+    - bskinn
+- name: scipy
+  url: https://docs.scipy.org/doc/scipy/
+  tags:
+    - bskinn
+- name: scipy
+  version: 1.6.3
+  url: https://docs.scipy.org/doc/scipy-1.6.3/reference/
+  tags:
+    - bskinn
+- name: scipy
+  version: 1.7.0
+  url: https://docs.scipy.org/doc/scipy-1.7.0/
+  tags:
+    - bskinn
+- name: scipy
+  version: 1.7.1
+  url: https://docs.scipy.org/doc/scipy-1.7.1/
+  tags:
+    - bskinn
+- name: scipy
+  version: 1.8.0
+  url: https://docs.scipy.org/doc/scipy-1.8.0/
+  tags:
+    - bskinn
+- name: scipy
+  version: 1.8.1
+  url: https://docs.scipy.org/doc/scipy-1.8.1/
+  tags:
+    - bskinn
+- name: sarge
+  url: https://sarge.readthedocs.io/en/latest/
+  tags:
+    - bskinn
+- name: linksmith
+  url: https://linksmith.readthedocs.io/en/latest/
+  tags:
+    - amotl

--- a/linksmith/sphinx/community/curated.yaml
+++ b/linksmith/sphinx/community/curated.yaml
@@ -1,11 +1,11 @@
 - name: python
-  version: 3
-  url: https://docs.python.org/3/
+  version: "3.9"
+  url: https://docs.python.org/3.9/
   tags:
     - bskinn
 - name: python
-  version: 3.9
-  url: https://docs.python.org/3.9/
+  version: "3.12"
+  url: https://docs.python.org/3.12/
   tags:
     - bskinn
 - name: attrs
@@ -17,17 +17,17 @@
   tags:
     - bskinn
 - name: flask
-  version: 1.1
+  version: "1.1"
   url: https://flask.palletsprojects.com/en/1.1.x/
   tags:
     - bskinn
 - name: flask
-  version: 2.2
+  version: "2.2"
   url: https://flask.palletsprojects.com/en/2.2.x/
   tags:
     - bskinn
 - name: flask
-  version: 3.0
+  version: "3.0"
   url: https://flask.palletsprojects.com/en/3.0.x/
   tags:
     - bskinn
@@ -68,27 +68,27 @@
   tags:
     - bskinn
 - name: scipy
-  version: 1.6.3
+  version: "1.6.3"
   url: https://docs.scipy.org/doc/scipy-1.6.3/reference/
   tags:
     - bskinn
 - name: scipy
-  version: 1.7.0
+  version: "1.7.0"
   url: https://docs.scipy.org/doc/scipy-1.7.0/
   tags:
     - bskinn
 - name: scipy
-  version: 1.7.1
+  version: "1.7.1"
   url: https://docs.scipy.org/doc/scipy-1.7.1/
   tags:
     - bskinn
 - name: scipy
-  version: 1.8.0
+  version: "1.8.0"
   url: https://docs.scipy.org/doc/scipy-1.8.0/
   tags:
     - bskinn
 - name: scipy
-  version: 1.8.1
+  version: "1.8.1"
   url: https://docs.scipy.org/doc/scipy-1.8.1/
   tags:
     - bskinn

--- a/linksmith/sphinx/core.py
+++ b/linksmith/sphinx/core.py
@@ -25,13 +25,17 @@ def dump_inventory_universal(infiles: t.List[str], format_: str = "text"):
             infiles = [str(local_objects_inv)]
         except Exception as ex:
             raise FileNotFoundError(f"No inventory specified, and none discovered: {ex}")
+
+    # Pre-flight checks.
+    for infile in infiles:
+        ResourceType.detect(infile)
+
+    # Process input files.
     for infile in infiles:
         if infile.endswith(".inv"):
             inventory_to_text(infile, format_=format_)
         elif infile.endswith(".txt"):
             inventories_to_text(infile, format_=format_)
-        else:
-            raise NotImplementedError(f"Unknown input file type: {infile}")
 
 
 def inventory_to_text(url: str, format_: str = "text"):

--- a/linksmith/sphinx/util.py
+++ b/linksmith/sphinx/util.py
@@ -1,4 +1,10 @@
+import logging
+import re
 from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
 
 
 class LocalObjectsInv:
@@ -27,3 +33,72 @@ class LocalObjectsInv:
             if path.exists():
                 return path
         raise FileNotFoundError("No objects.inv found in working directory")
+
+
+class RemoteObjectsInv:
+    """
+    Support discovering an `objects.inv` on Read the Docs.
+    """
+
+    HTTP_TIMEOUT = 5
+
+    def __init__(self, project: str):
+        self.project = project
+
+    def discover(self) -> str:
+        try:
+            return self.discover_rtd()
+        except FileNotFoundError:
+            return self.discover_pypi()
+
+    def discover_rtd(self) -> str:
+        logger.info(f"Attempting to resolve project through RTD: {self.project}")
+        try:
+            result = requests.get(
+                "https://readthedocs.org/api/v3/search/",
+                params={"q": f"project:{self.project} *"},
+                timeout=self.HTTP_TIMEOUT,
+            ).json()["results"][0]
+        except IndexError:
+            raise FileNotFoundError(f"Project not found at Read the Docs: {self.project}")
+        domain = result["domain"]
+        path = result["path"]
+
+        # No way to discover the language slot via API?
+        # Derive `/en/latest/` into `/en/latest/objects.inv`. (requests)
+        # Derive `/en/stable/examples.html` into `/en/stable/objects.inv`. (requests-cache)
+        # Derive `/genindex.html` into `/objects.inv`. (cratedb-guide)
+        # TODO: Also handle nested URLs like `/en/latest/snippets/myst/dropdown-group.html`.
+        path = re.sub(r"(.*)/.*\.html?$", "\\1", path)
+
+        rtd_url = f"{domain}/{path}"
+        rtd_exists = requests.get(rtd_url, allow_redirects=True, timeout=self.HTTP_TIMEOUT).status_code == 200
+
+        if rtd_exists:
+            return rtd_url
+
+        raise FileNotFoundError("No objects.inv discovered through Read the Docs")
+
+    def discover_pypi(self) -> str:
+        logger.info(f"Attempting to resolve project through PyPI: {self.project}")
+        pypi_url = f"https://pypi.org/pypi/{self.project}/json"
+        metadata = requests.get(pypi_url, timeout=self.HTTP_TIMEOUT).json()
+        docs_url = metadata["info"]["docs_url"]
+        home_page = metadata["info"]["home_page"]
+        home_page2 = metadata["info"]["project_urls"]["Homepage"]
+        for candidate in docs_url, home_page, home_page2:
+            if candidate is None:
+                continue
+            objects_inv_candidate = f"{candidate.rstrip('/')}/objects.inv"
+            try:
+                objects_inv_status = requests.get(
+                    objects_inv_candidate,
+                    allow_redirects=True,
+                    timeout=self.HTTP_TIMEOUT,
+                ).status_code
+                if objects_inv_status < 400:
+                    return candidate
+            except Exception:  # noqa: S110
+                pass
+
+        raise FileNotFoundError("No objects.inv discovered through PyPI")

--- a/linksmith/util/data.py
+++ b/linksmith/util/data.py
@@ -1,0 +1,45 @@
+from functools import cmp_to_key
+from operator import attrgetter, itemgetter
+
+
+def multikeysort(items, *columns, attrs=True) -> list:
+    """
+    Perform a multiple column sort on a list of dictionaries or objects.
+    Args:
+        items (list): List of dictionaries or objects to be sorted.
+        *columns: Columns to sort by, optionally preceded by a '-' for descending order.
+        attrs (bool): True if items are objects, False if items are dictionaries.
+
+    Returns:
+        list: Sorted list of items.
+
+    Source: https://stackoverflow.com/a/77401782. Thanks, @pymen.
+    """
+    getter = attrgetter if attrs else itemgetter
+
+    def get_comparers():
+        comparers = []
+
+        for col in columns:
+            col = col.strip()
+            if col.startswith("-"):  # If descending, strip '-' and create a comparer with reverse order
+                key = getter(col[1:])
+                order = -1
+            else:  # If ascending, use the column directly
+                key = getter(col)
+                order = 1
+
+            comparers.append((key, order))
+        return comparers
+
+    def custom_compare(left, right):
+        """Custom comparison function to handle multiple keys"""
+        for fn, reverse in get_comparers():
+            # Minor enhancement when to-be-compared attribute values are `None`.
+            if fn(left) is not None and fn(right) is not None:
+                result = (fn(left) > fn(right)) - (fn(left) < fn(right))
+                if result != 0:
+                    return result * reverse
+        return 0
+
+    return sorted(items, key=cmp_to_key(custom_compare))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Andreas Motl", email = "andreas.motl@panodata.org" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Environment :: Web Environment",
@@ -52,7 +52,6 @@ classifiers = [
   "Intended Audience :: Telecommunications Industry",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dependencies = [
   "sphinx<7.3",
   "sphobjinv<2.4",
   "tabulate<0.10",
+  "verlib2==0.2.0",
 ]
 [project.optional-dependencies]
 develop = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Andreas Motl", email = "andreas.motl@panodata.org" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Environment :: Web Environment",
@@ -52,7 +52,6 @@ classifiers = [
   "Intended Audience :: Telecommunications Industry",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/tests/test_anansi.py
+++ b/tests/test_anansi.py
@@ -2,6 +2,16 @@ import linksmith
 from linksmith.cli import cli
 
 
+def test_anansi_list_projects(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi list-projects",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "matplotlib" in result.output
+
+
 def test_anansi_pure(cli_runner):
     result = cli_runner.invoke(
         cli,

--- a/tests/test_anansi.py
+++ b/tests/test_anansi.py
@@ -69,3 +69,23 @@ def test_anansi_suggest_miss(cli_runner, caplog):
     )
     assert result.exit_code == 0
     assert "No hits for project/term: sarge/foo" in caplog.messages
+
+
+def test_anansi_suggest_via_rtd(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest requests-cache patch --threshold=75",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert ":std:label:`patching`" in result.output
+
+
+def test_anansi_suggest_via_pypi(cli_runner):
+    result = cli_runner.invoke(
+        cli,
+        args="anansi suggest beradio json",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert ":py:method:`beradio.message.BERadioMessage.json`" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def test_cli_output_formats(cli_runner):
     assert result.exit_code == 0
 
 
-def test_cli_inventory_unknown_input(cli_runner):
+def test_cli_inventory_file_not_found(cli_runner):
     """
     CLI test: Invoke `linksmith inventory example.foo`.
     """
@@ -38,20 +38,20 @@ def test_cli_inventory_unknown_input(cli_runner):
         catch_exceptions=False,
     )
     assert result.exit_code == 1
-    assert "Unknown input file type: example.foo" in result.output
+    assert "Resource not found: example.foo" in result.output
 
 
 def test_cli_inventory_unknown_input_with_debug(cli_runner):
     """
     CLI test: Invoke `linksmith inventory example.foo`.
     """
-    with pytest.raises(NotImplementedError) as ex:
+    with pytest.raises(FileNotFoundError) as ex:
         cli_runner.invoke(
             cli,
             args="--debug inventory example.foo",
             catch_exceptions=False,
         )
-    assert ex.match("Unknown input file type: example.foo")
+    assert ex.match("Resource not found: example.foo")
 
 
 def test_cli_single_inventory_path(cli_runner):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,13 +44,13 @@ def test_unknown_output_format():
     ex.match("Output format not implemented: foo-format")
 
 
-def test_unknown_input_format_single():
-    with pytest.raises(NotImplementedError) as ex:
+def test_file_not_found_format_single():
+    with pytest.raises(FileNotFoundError) as ex:
         inventory_to_text("foo.bar", "text")
-    ex.match("Resource type not implemented: foo.bar")
+    ex.match("Resource not found: foo.bar")
 
 
-def test_unknown_input_format_multiple():
-    with pytest.raises(NotImplementedError) as ex:
+def test_file_not_found_format_multiple():
+    with pytest.raises(FileNotFoundError) as ex:
         inventories_to_text("foo.bar", "text")
-    ex.match("Resource type not implemented: foo.bar")
+    ex.match("Resource not found: foo.bar")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,7 +33,6 @@ tests/assets/sde.inv
     inventories_to_text(urls, format_)
 
 
-@pytest.mark.skip("Does not work yet")
 def test_multiple_inventories_url():
     url = "https://github.com/tech-writing/linksmith/raw/main/tests/assets/index.txt"
     inventories_to_text(url, "html")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -23,11 +23,11 @@ def test_inventory_omit_documents(capsys):
     assert "std:doc" not in out
 
 
-def test_inventory_manager_unknown():
+def test_inventory_manager_file_not_found():
     invman = InventoryManager("foo")
-    with pytest.raises(NotImplementedError) as ex:
+    with pytest.raises(FileNotFoundError) as ex:
         invman.soi_factory()
-    assert ex.match("Resource type not implemented: foo")
+    assert ex.match("Resource not found: foo")
 
 
 def test_cli_inventory_autodiscover(capsys):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,7 +28,7 @@ def test_resource_type_buffer():
     assert ResourceType.detect(buffer) is ResourceType.BUFFER
 
 
-def test_resource_type_unknown():
-    with pytest.raises(NotImplementedError) as ex:
+def test_resource_not_found_file():
+    with pytest.raises(FileNotFoundError) as ex:
         ResourceType.detect("foobar")
-    assert ex.match("Resource type not implemented: foobar")
+    assert ex.match("Resource not found: foobar")


### PR DESCRIPTION
- Inventory: Accept `linksmith inventory` without `INFILES` argument
- Inventory: Improve pre-flight checks
- Anansi: Manage project list in YAML file `curated.yaml`, not Python
- Anansi: Provide `anansi list-projects` subcommand
- Anansi: Fix sort order of index file, use "by name asc/by version desc"
- Anansi: Accept `--threshold` option, forwarding to `sphobjinv`
- Anansi: Discover `objects.inv` also from RTD and PyPI
- Chore: Activate test case `test_multiple_inventories_url`
- Chore: Remove support for Python 3.7 and 3.8
